### PR TITLE
[Feature] Draft Layout for 1000px Width Breakpoint

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -290,4 +290,124 @@ button:focus {
   width: 94%;
 }
 
+@media screen and (max-width: 1000px) {
+  html, body {
+    font-size: 14px;
+  }
 
+  body {
+    height: 200vh;
+  }
+
+  nav {
+    height: 3%;
+  }
+
+  main {
+    flex-direction: column;
+    align-items: center;
+    height: 95%;
+    margin-top: 11%;
+  }
+
+  .cards {
+    width: 100%;
+    height: 60%;
+  }
+
+  .infographic {
+    width: 100%;
+    height: 35%;
+    margin: 5% 0 0 1%;
+    margin-left: 0;
+  }
+
+  .activity-card-js, .hydration-holder, .latest-sleep-data-js {
+    margin-top: 1%;
+    width: 100%;
+  }
+
+  .nav-left-container {
+    width: 100%;
+  }
+
+  h2 {
+    margin-block-end: 1%;
+  }
+
+  .stat-card-wrapper {
+    flex-direction: column;
+    align-items: center;
+    height: 70%;
+    margin-top: 2%;
+  }
+
+  .stat-cards {
+    width: 100%;
+    margin: 0;
+    height: 28%;
+    justify-content: center;
+    padding: 0;
+  }
+
+  aside {
+    display: block;
+  }
+
+  .user-profile-card {
+    flex-direction: column;
+    align-items: center;
+    min-height: 15%;
+    max-height: 20%;
+    padding: 0;
+    margin-top: 2%;
+  }
+
+  .user-info-wrapper {
+    flex-direction: column;
+    align-items: space-between;
+    flex-wrap: wrap;
+    height: 100%;
+  }
+
+  .user-name-profile-backing {
+    display: none;
+  }
+
+  .user-name-profile {
+    font-size: 1.5rem;
+  }
+
+  .profile-info {
+    width: 30%;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    justify-content: flex-start;
+    padding: 2% 1%;
+  }
+
+  .personal-info, .goal-steps-info {
+    border: 0;
+  }
+
+  .button-wrapper {
+    position: absolute;
+    top: 0;
+    right: 2%;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    width: 30%;
+  }
+
+  button {
+    padding: 0.5%;
+    height: 30%;
+  }
+
+  .sleep-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
### Types of changes made?

- [x]  CSS Styling

### What does this PR do?

- Creates a media query and associated CSS style properties/selectors for screens below the 1000 pixel width breakpoint where the original layout began to break.
- Introduces a stacked column format for smaller screens.

### Relevant Tickets?

- Contributes to [The website should be responsive for tablets and smaller non-mobile monitors.#151](https://github.com/JWFeatherstone/fitlit-adriane-houda-sam-john/issues/151)

### Questions/Comments/Relevant Screenshots?

- Need to do further testing at smaller breakpoints and on mobiles to see if further media queries or changes to this format are needed.