### PR TITLE
[Fix] Map Error Graphic 

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -188,6 +188,7 @@ function displayActivityCard(activity, user, date) {
 // Chart Functions
 function clearChartArea() {
   const chartArea = document.querySelector(".infographic");
+  chartArea.classList.remove("map-error");
   chartArea.classList.remove("chart-placeholder");
   chartArea.innerHTML = `
   <div id="map"></div>
@@ -300,10 +301,6 @@ function createMap(user) {
     .catch((error) => {
       console.error('Error:', error);
       chartArea.classList.add("map-error");
-      setTimeout(() => {
-        chartArea.classList.remove("map-error");
-        chartArea.classList.add("chart-placeholder");
-      }, 3000);
     });
 }
 


### PR DESCRIPTION
Quick fix to alter the map error graphic/message so that it remains up until the user selects another chart to display in line with the other buttons.