### PR TITLE
Remove margin to fix overlap and add modal title back to modal

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -67,7 +67,7 @@
       <div class="modal micromodal-slide" id="hydrationModal" aria-hidden="true">
         <div class="modal-overlay" tabindex="-1" data-micromodal-close>
           <div class="modal-container" role="dialog" aria-modal="true" aria-labelledby="modal-1-title">
-            <h2 class="modal-title"></h2>
+            <h2 class="modal-title">Hydration Input</h2>
             <main class="modal-content">
               <form id="form">
                 <label for="waterIntake" class="form-water-intake" id="waterIntakeLabel">Ounces Drank</label>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -25,7 +25,7 @@ body {
 
 p {
   font-size: 0.9rem;
-  margin: 0.1rem 0 0.6rem 0;
+  margin: 0.1rem 0 0 0;
   color: rgb(49, 49, 49);
 }
 
@@ -454,12 +454,12 @@ button:focus {
 }
 
 .modal-title {
-  margin: 0;
+  margin: 5% 0 0 0;
   font-weight: 600; 
   line-height: 1.50;  
   color: rgba(56, 44, 94);
   box-sizing: border-box;
-  padding-left: 30%;
+  padding: 0 0 0 30%;
  
 }
 
@@ -474,7 +474,7 @@ button:focus {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin: 15% 0;
+  margin: 5% 0 0 0;
   line-height: 1.5;
   color: rgb(49, 49, 49);;
 }


### PR DESCRIPTION
### Types of changes made?
- [x] CSS
- [x] HTML
### What does this PR do?
Updates CSS to fix overlap 
Adds title back to the modal

<img width="1440" alt="Screenshot 2023-04-15 at 10 28 39 AM" src="https://user-images.githubusercontent.com/118500762/232243562-02701b5a-5bb8-40c1-80b0-18fb5bf8c222.png">
